### PR TITLE
Sensor parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog for package urdfdom_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 0.4.3 (2020-04-01)
------------
+------------------
 * Remove lxml dependency (`#57 <https://github.com/ros/urdf_parser_py/issues/57>`_)
 * Use setuptools instead of distutils (`#56 <https://github.com/ros/urdf_parser_py/issues/56>`_)
 * Bump CMake version to avoid CMP0048 (`#55 <https://github.com/ros/urdf_parser_py/issues/55>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package urdfdom_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.4.6 (2021-10-04)
+------------------
 * Support name attribute for collisions (`#67 <https://github.com/ros/urdf_parser_py/issues/67>`_)
 * Contributors: Nick Lamprianidis
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package urdfdom_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Replace deprecated function (`#60 <https://github.com/ros/urdf_parser_py/issues/60>`_)
+* Contributors: Roel
+
 0.4.3 (2020-04-01)
 ------------------
 * Remove lxml dependency (`#57 <https://github.com/ros/urdf_parser_py/issues/57>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package urdfdom_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.4.5 (2020-12-04)
+------------------
 * Make sure to add the version when creating a new URDF. (`#62 <https://github.com/ros/urdf_parser_py/issues/62>`_) (`#66 <https://github.com/ros/urdf_parser_py/issues/66>`_)
 * Contributors: Chris Lalancette
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package urdfdom_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Support name attribute for collisions (`#67 <https://github.com/ros/urdf_parser_py/issues/67>`_)
+* Contributors: Nick Lamprianidis
+
 0.4.5 (2020-12-04)
 ------------------
 * Make sure to add the version when creating a new URDF. (`#62 <https://github.com/ros/urdf_parser_py/issues/62>`_) (`#66 <https://github.com/ros/urdf_parser_py/issues/66>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package urdfdom_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.4.3 (2020-04-01)
+-----------
+* Remove lxml dependency (`#57 <https://github.com/ros/urdf_parser_py/issues/57>`_)
+* Use setuptools instead of distutils (`#56 <https://github.com/ros/urdf_parser_py/issues/56>`_)
+* Bump CMake version to avoid CMP0048 (`#55 <https://github.com/ros/urdf_parser_py/issues/55>`_)
+* update backward compatibility on visual and collisions (`#47 <https://github.com/ros/urdf_parser_py/issues/47>`_)
+* Allow name attribute in visual tag (`#31 <https://github.com/ros/urdf_parser_py/issues/31>`_)
+* Contributors: Kei Okada, Shane Loretz, gerkey
+
 0.4.2 (2020-01-22)
 ------------------
 * Add in support for the version tag. (`#52 <https://github.com/ros/urdf_parser_py/issues/52>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package urdfdom_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.4.4 (2020-10-29)
+------------------
 * Replace deprecated function (`#60 <https://github.com/ros/urdf_parser_py/issues/60>`_)
 * Contributors: Roel
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package urdfdom_py
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Make sure to add the version when creating a new URDF. (`#62 <https://github.com/ros/urdf_parser_py/issues/62>`_) (`#66 <https://github.com/ros/urdf_parser_py/issues/66>`_)
+* Contributors: Chris Lalancette
+
 0.4.4 (2020-10-29)
 ------------------
 * Replace deprecated function (`#60 <https://github.com/ros/urdf_parser_py/issues/60>`_)

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>urdfdom_py</name>
-  <version>0.4.3</version>
+  <version>0.4.4</version>
   <description>Python implementation of the URDF parser.</description>
 
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>urdfdom_py</name>
-  <version>0.4.5</version>
+  <version>0.4.6</version>
   <description>Python implementation of the URDF parser.</description>
 
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>urdfdom_py</name>
-  <version>0.4.4</version>
+  <version>0.4.5</version>
   <description>Python implementation of the URDF parser.</description>
 
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>urdfdom_py</name>
-  <version>0.4.2</version>
+  <version>0.4.3</version>
   <description>Python implementation of the URDF parser.</description>
 
   <license>BSD</license>

--- a/package.xml
+++ b/package.xml
@@ -27,9 +27,6 @@
 
   <exec_depend>rospy</exec_depend>
 
-  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-lxml</exec_depend>
-  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-lxml</exec_depend>
-
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>
 

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -149,12 +149,14 @@ xmlr.add_type('geometric', GeometricType())
 
 
 class Collision(xmlr.Object):
-    def __init__(self, geometry=None, origin=None):
+    def __init__(self, geometry=None, origin=None, name=None):
         self.geometry = geometry
+        self.name = name
         self.origin = origin
 
 
 xmlr.reflect(Collision, tag='collision', params=[
+    xmlr.Attribute('name', str, False),
     origin_element,
     xmlr.Element('geometry', 'geometric')
 ])

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -481,12 +481,16 @@ xmlr.add_type('transmission',
 
 
 class Robot(xmlr.Object):
-    def __init__(self, name=None, version=None):
+    SUPPORTED_VERSIONS = ["1.0"]
+
+    def __init__(self, name=None, version="1.0"):
         self.aggregate_init()
 
         self.name = name
-        if version is not None:
-            self.version = version
+        if version not in self.SUPPORTED_VERSIONS:
+            raise ValueError("Invalid version; only %s is supported" % (','.join(self.SUPPORTED_VERSIONS)))
+
+        self.version = version
         self.joints = []
         self.links = []
         self.materials = []
@@ -559,8 +563,8 @@ class Robot(xmlr.Object):
         if int(split[0]) < 0 or int(split[1]) < 0:
             raise ValueError("Version number must be positive")
 
-        if self.version != "1.0":
-            raise ValueError("Invalid version; only 1.0 is supported")
+        if self.version not in self.SUPPORTED_VERSIONS:
+            raise ValueError("Invalid version; only %s is supported" % (','.join(self.SUPPORTED_VERSIONS)))
 
     @classmethod
     def from_parameter_server(cls, key='robot_description'):

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -525,6 +525,9 @@ class TactileArray(Tactile):
     def __init__(self, channel=None,  array=None):
         Tactile.__init__(self, channel=channel)
         self.array = array
+    # the test is very important in DuckTyping, if no fail, won't test the second type
+    def check_valid(self):
+        assert self.array is not None
 
 
 xmlr.reflect(TactileArray, tag='tactile_array', params=[
@@ -554,6 +557,9 @@ class TactileTaxels(Tactile):
         Tactile.__init__(self, channel=channel)
         self.taxel = taxel
         self.taxels=[]
+    # the test is very important in DuckTyping, if no fail, won't test the second type
+    def check_valid(self):
+        assert self.taxel is not None
 
 xmlr.reflect(TactileTaxels, tag='tactile_taxels', params=[
     xmlr.Attribute('channel', str),

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -339,6 +339,7 @@ class Joint(xmlr.Object):
     @joint_type.setter
     def joint_type(self, value): self.type = value
 
+
 xmlr.reflect(Joint, tag='joint', params=[
     name_attribute,
     xmlr.Attribute('type', str),
@@ -486,16 +487,17 @@ xmlr.add_type('transmission',
 # add the vector2 type
 get_type('vector2')
 
+
 class Tactile(xmlr.Object):
     def __init__(self, channel=None):
         self.channel = channel
 
 
 class TactileArrayElement(xmlr.Object):
-    ROWMAJOR="row-major"
-    COLUMNMAJOR="column-major"
-    def __init__(self, rows=None, cols=None, order=None,
-        size=None, spacing=None, offset=None):
+    ROWMAJOR = "row-major"
+    COLUMNMAJOR = "column-major"
+
+    def __init__(self, rows=None, cols=None, order=None, size=None, spacing=None, offset=None):
         self.rows = rows
         self.cols = cols
         self.order = order
@@ -509,10 +511,11 @@ class TactileArrayElement(xmlr.Object):
         # fix int here, it appears to not be possible in init because params are not set at init
         self.rows = int(self.rows) if self.rows is not None else None
         self.cols = int(self.cols) if self.cols is not None else None
-        assert self.order in [self.ROWMAJOR, self.COLUMNMAJOR], ("order should be " + str(self.ROWMAJOR) + " or " + str(self.COLUMNMAJOR))
+        assert self.order in [self.ROWMAJOR, self.COLUMNMAJOR], ("order should be " +
+                                                                 str(self.ROWMAJOR) + " or " + str(self.COLUMNMAJOR))
 
 
-#xmlr.add_type('geometric', TactileArrayElement())
+# xmlr.add_type('geometric', TactileArrayElement())
 
 xmlr.reflect(TactileArrayElement, tag='tactile_array_element', params=[
     xmlr.Attribute('rows', float),
@@ -529,6 +532,7 @@ class TactileArray(Tactile):
         Tactile.__init__(self, channel=channel)
         self.array = array
         self.taxel = None
+
     # the test is very important in DuckTyping, if no fail, won't test the second type
     def check_valid(self):
         assert self.array is not None
@@ -550,17 +554,18 @@ class TactileTaxelElement(xmlr.Object):
 
 
 xmlr.reflect(TactileTaxelElement, tag='array', params=[
-    xmlr.Attribute('idx', float), 
+    xmlr.Attribute('idx', float),
     xmlr.Attribute('xyz', 'vector3', False, default=[0, 0, 0]),
     xmlr.Attribute('rpy', 'vector3', False, default=[0, 0, 0]),
     xmlr.Element('geometry', 'geometric'),
 ])
 
+
 class TactileTaxels(Tactile):
     def __init__(self, channel=None, taxel=None):
         Tactile.__init__(self, channel=channel)
         self.aggregate_init()
-        self.taxels=[]
+        self.taxels = []
         if taxel:
             self.taxel = taxel
         self.array = None
@@ -578,11 +583,11 @@ class TactileTaxels(Tactile):
             self.taxels.append(taxel)
         if taxel:
             self.add_aggregate('taxel', taxel)
-    
+
     # the test is very important in DuckTyping, if no fail, won't test the second type
     def check_valid(self):
         assert self.taxel is not None
-        
+
     # Properties setter getter
     taxel = property(__get_taxel, __set_taxel)
 
@@ -602,8 +607,7 @@ xmlr.add_type('tactile',
 class Sensor(xmlr.Object):
     """ UBI Sensor Base """
 
-    def __init__(self, name=None, group=None, update_rate=None,
-        parent=None, origin=None):
+    def __init__(self, name=None, group=None, update_rate=None, parent=None, origin=None):
         self.name = name
         self.group = group
         self.update_rate = update_rate
@@ -614,20 +618,20 @@ class Sensor(xmlr.Object):
 
 class SensorTactile(Sensor):
     """ UBI Sensor format """
-             
-    def __init__(self, name=None, group=None, update_rate=None,
-        parent=None, origin=None, tactile=None):
+
+    def __init__(self, name=None, group=None, update_rate=None, parent=None, origin=None, tactile=None):
         Sensor.__init__(self, name, group, update_rate, parent, origin)
         # one cannot just pass self.tactile to a sensor initialization
-        # reflect needs the parameter to be part of the object so 
+        # reflect needs the parameter to be part of the object so
         # member tactile is nedded
-        self.tactile=tactile
-        self.sensor=self.tactile
+        self.tactile = tactile
+        self.sensor = self.tactile
 
     def check_valid(self):
         # this test cannot be generalized to test sensor in the base class
         # because the check occurs before the parent element is filled
         assert self.tactile is not None, "no sensor defined"
+
 
 xmlr.reflect(SensorTactile, tag='sensor_tactile', params=[
     name_attribute,
@@ -640,15 +644,15 @@ xmlr.reflect(SensorTactile, tag='sensor_tactile', params=[
 
 
 class RayElement(xmlr.Object):
-    def __init__(self, samples=None, resolution=None,
-        min_angle=None, max_angle=None):
-        self.samples = int(samples) if samples is not None else None 
+    def __init__(self, samples=None, resolution=None, min_angle=None, max_angle=None):
+        self.samples = int(samples) if samples is not None else None
         self.resolution = int(resolution) if resolution is not None else None
         self.min_angle = min_angle
         self.max_angle = max_angle
 
     def check_valid(self):
         assert self.samples is not None
+
 
 xmlr.reflect(RayElement, tag='ray_element', params=[
     xmlr.Attribute('samples', float),
@@ -660,8 +664,8 @@ xmlr.reflect(RayElement, tag='ray_element', params=[
 
 class Ray(xmlr.Object):
     def __init__(self, horizontal=None, vertical=None):
-        self.horizontal=horizontal
-        self.vertical=vertical
+        self.horizontal = horizontal
+        self.vertical = vertical
 
     def check_valid(self):
         assert self.horizontal is not None and self.vertical is not None
@@ -675,16 +679,15 @@ xmlr.reflect(Ray, tag='ray', params=[
 
 class SensorRay(Sensor):
     """ UBI Sensor format """
-             
-    def __init__(self, name=None, group=None, update_rate=None,
-        parent=None, origin=None, ray=None):
+
+    def __init__(self, name=None, group=None, update_rate=None, parent=None, origin=None, ray=None):
         Sensor.__init__(self, name, group, update_rate, parent, origin)
         # one cannot just pass self.ray to a sensor initialization
-        # reflect needs the parameter to be part of the object so 
+        # reflect needs the parameter to be part of the object so
         # member ray is nedded
         self.ray = ray
         self.sensor = self.ray
-    
+
     def check_valid(self):
         # this test cannot be generalized to test sensor in the base class
         # because the check occurs before the parent element is filled
@@ -702,9 +705,8 @@ xmlr.reflect(SensorRay, tag='sensor_ray', params=[
 
 
 class CameraImage(xmlr.Object):
-    def __init__(self, width=None, height=None,
-        format="R8G8B8", hfov=None, near=None, far=None):
-        self.width = int(width) if width is not None else None 
+    def __init__(self, width=None, height=None, format="R8G8B8", hfov=None, near=None, far=None):
+        self.width = int(width) if width is not None else None
         self.height = int(height) if height is not None else None
         # format is optional: defaults to R8G8B8), but can be
         # (L8|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)
@@ -715,6 +717,7 @@ class CameraImage(xmlr.Object):
 
     def check_valid(self):
         assert self.width is not None
+
 
 xmlr.reflect(CameraImage, tag='image', params=[
     xmlr.Attribute('width', float),
@@ -733,6 +736,7 @@ class Camera(xmlr.Object):
     def check_valid(self):
         assert self.image is not None
 
+
 xmlr.reflect(Camera, tag='camera', params=[
     xmlr.Element('image', CameraImage, False)
 ])
@@ -740,16 +744,15 @@ xmlr.reflect(Camera, tag='camera', params=[
 
 class SensorCamera(Sensor):
     """ UBI Sensor format """
-             
-    def __init__(self, name=None, group=None, update_rate=None,
-        parent=None, origin=None, camera=None):
+
+    def __init__(self, name=None, group=None, update_rate=None, parent=None, origin=None, camera=None):
         Sensor.__init__(self, name, group, update_rate, parent, origin)
         # one cannot just pass self.camera to a sensor initialization
-        # reflect needs the parameter to be part of the object so 
+        # reflect needs the parameter to be part of the object so
         # member camera is nedded
         self.camera = camera
         self.sensor = self.camera
-    
+
     def check_valid(self):
         # this test cannot be generalized to test sensor in the base class
         # because the check occurs before the parent element is filled
@@ -768,6 +771,7 @@ xmlr.reflect(SensorCamera, tag='sensor_camera', params=[
 
 class UnknownType(xmlr.ValueType):
     name = "unknown"
+
     def from_xml(self, node, path):
         self.node = node
         return self
@@ -780,9 +784,11 @@ class UnknownType(xmlr.ValueType):
         for (attrib_key, attrib_value) in self.node.attrib.items():
             node.set(attrib_key, attrib_value)
 
+
 xmlr.add_type('sensor',
               xmlr.DuckTypedFactory('sensor',
                                     [SensorCamera, SensorRay, SensorTactile, UnknownType()]))
+
 
 class Robot(xmlr.Object):
     SUPPORTED_VERSIONS = ["1.0"]
@@ -825,7 +831,7 @@ class Robot(xmlr.Object):
             self.link_map[link.name] = link
         elif typeName == 'sensor':
             sensor = elem
-            if not isinstance (sensor , UnknownType):
+            if not isinstance(sensor, UnknownType):
                 self.sensor_map[sensor.name] = sensor
 
     def add_link(self, link):

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -500,10 +500,12 @@ class TactileArrayElement(xmlr.Object):
         self.cols = int(cols) if cols is not None else None
         self.order = order
         self.size = size
-        self.spacing = spacing
         self.offset = offset
+        self.spacing = spacing
 
     def check_valid(self):
+        if self.spacing is None:
+            self.spacing = self.size
         assert self.order in [self.ROWMAJOR, self.COLUMNMAJOR], ("order should be " + str(self.ROWMAJOR) + " or " + str(self.COLUMNMAJOR))
 
 
@@ -514,7 +516,7 @@ xmlr.reflect(TactileArrayElement, tag='tactile_array_element', params=[
     xmlr.Attribute('cols', float),
     xmlr.Attribute('order', str, False, default="row-major"),
     xmlr.Attribute('size', 'vector2'),
-    xmlr.Attribute('spacing', 'vector2', False, default=[0, 0]),
+    xmlr.Attribute('spacing', 'vector2', False),
     xmlr.Attribute('offset', 'vector2', False, default=[0, 0])
 ])
 

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -636,6 +636,67 @@ xmlr.reflect(SensorTactile, tag='sensor_tactile', params=[
 ])
 
 
+class RayElement(xmlr.Object):
+    def __init__(self, samples=None, resolution=None,
+        min_angle=None, max_angle=None):
+        self.samples = int(samples) if samples is not None else None 
+        self.resolution = int(resolution) if resolution is not None else None
+        self.min_angle = min_angle
+        self.max_angle = max_angle
+
+    def check_valid(self):
+        assert self.samples is not None
+
+xmlr.reflect(RayElement, tag='ray_element', params=[
+    xmlr.Attribute('samples', float),
+    xmlr.Attribute('resolution', float),
+    xmlr.Attribute('min_angle', float),
+    xmlr.Attribute('max_angle', float)
+])
+
+
+class Ray(xmlr.Object):
+    def __init__(self, horizontal=None, vertical=None):
+        self.horizontal=horizontal
+        self.vertical=vertical
+
+    def check_valid(self):
+        assert self.horizontal is not None and self.vertical is not None
+
+
+xmlr.reflect(Ray, tag='ray', params=[
+    xmlr.Element('horizontal', RayElement),
+    xmlr.Element('vertical', RayElement)
+])
+
+
+class SensorRay(Sensor):
+    """ UBI Sensor format """
+             
+    def __init__(self, name=None, group=None, update_rate=None,
+        parent=None, origin=None, ray=None):
+        Sensor.__init__(self, name, group, update_rate, parent, origin)
+        # one cannot just pass self.ray to a sensor initialization
+        # reflect needs the parameter to be part of the object so 
+        # member ray is nedded
+        self.ray = ray
+        self.sensor = self.ray
+    
+    def check_valid(self):
+        # this test cannot be generalized to test sensor in the base class
+        # because the check occurs before the parent element is filled
+        assert self.ray is not None, "no sensor defined"
+
+
+xmlr.reflect(SensorRay, tag='sensor_ray', params=[
+    name_attribute,
+    xmlr.Attribute('group', str, False, default=""),
+    xmlr.Attribute('update_rate', float),
+    xmlr.Element('parent', 'element_link', False),
+    origin_element,
+    xmlr.Element('ray', Ray)
+])
+
 
 class CameraImage(xmlr.Object):
     def __init__(self, width=None, height=None,

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -487,10 +487,8 @@ xmlr.add_type('transmission',
 get_type('vector2')
 
 class Tactile(xmlr.Object):
-    def __init__(self, channel=None, taxels=[], array=None):
+    def __init__(self, channel=None):
         self.channel = channel
-        self.taxels = taxels
-        self.array = array
 
 
 class TactileArrayElement(xmlr.Object):
@@ -523,7 +521,8 @@ xmlr.reflect(TactileArrayElement, tag='tactile_array_element', params=[
 
 class TactileArray(Tactile):
     def __init__(self, channel=None,  array=None):
-        Tactile.__init__(self, channel=channel, array=array)
+        Tactile.__init__(self, channel=channel)
+        self.array = array
 
 
 xmlr.reflect(TactileArray, tag='tactile_array', params=[
@@ -534,6 +533,7 @@ xmlr.reflect(TactileArray, tag='tactile_array', params=[
 
 class TactileTaxelElement(xmlr.Object):
     def __init__(self, idx=None, xyz=None, rpy=None, geometry=None):
+        self.aggregate_init()
         self.idx = int(idx) if idx is not None else None
         self.xyz = xyz
         self.rpy = rpy
@@ -548,9 +548,10 @@ xmlr.reflect(TactileTaxelElement, tag='tactile_taxel_element', params=[
 ])
 
 class TactileTaxels(Tactile):
-    def __init__(self, channel=None, idx=None, origin=None, taxel=None):
-        self.aggregate_init()
-        Tactile.__init__(self, channel=channel, taxels=taxel)
+    def __init__(self, channel=None, taxel=None):
+        Tactile.__init__(self, channel=channel)
+        self.taxel = taxel
+        self.taxels=[]
 
 xmlr.reflect(TactileTaxels, tag='tactile_taxels', params=[
     xmlr.Attribute('channel', str),

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -540,7 +540,6 @@ xmlr.reflect(TactileArray, tag='tactile', params=[
 
 class TactileTaxelElement(xmlr.Object):
     def __init__(self, idx=None, xyz=None, rpy=None, geometry=None):
-        self.aggregate_init()
         self.idx = int(idx) if idx is not None else None
         self.xyz = xyz
         self.rpy = rpy
@@ -557,12 +556,33 @@ xmlr.reflect(TactileTaxelElement, tag='array', params=[
 class TactileTaxels(Tactile):
     def __init__(self, channel=None, taxel=None):
         Tactile.__init__(self, channel=channel)
-        self.taxel = taxel
+        self.aggregate_init()
         self.taxels=[]
+        if taxel:
+            self.taxel = taxel
         self.array = None
+
+    def __get_taxel(self):
+        """Return the first taxel or None."""
+        if self.taxels:
+            return self.taxels[0]
+
+    def __set_taxel(self, taxel):
+        """Set the first taxel."""
+        if self.taxels:
+            self.taxels[0] = taxel
+        else:
+            self.taxels.append(taxel)
+        if taxel:
+            self.add_aggregate('taxel', taxel)
+    
     # the test is very important in DuckTyping, if no fail, won't test the second type
     def check_valid(self):
         assert self.taxel is not None
+        
+    # Properties setter getter
+    taxel = property(__get_taxel, __set_taxel)
+
 
 xmlr.reflect(TactileTaxels, tag='tactile', params=[
     xmlr.Attribute('channel', str),
@@ -573,7 +593,7 @@ xmlr.reflect(TactileTaxels, tag='tactile', params=[
 
 xmlr.add_type('tactile',
               xmlr.DuckTypedFactory('tactile',
-                                    [TactileArray, TactileTaxels]))
+                                    [TactileTaxels, TactileArray]))
 
 
 class Sensor(xmlr.Object):

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -522,17 +522,19 @@ xmlr.reflect(TactileArrayElement, tag='tactile_array_element', params=[
 
 
 class TactileArray(Tactile):
-    def __init__(self, channel=None,  array=None):
+    def __init__(self, channel=None, array=None):
         Tactile.__init__(self, channel=channel)
         self.array = array
+        self.taxel = None
     # the test is very important in DuckTyping, if no fail, won't test the second type
     def check_valid(self):
         assert self.array is not None
 
 
-xmlr.reflect(TactileArray, tag='tactile_array', params=[
+xmlr.reflect(TactileArray, tag='tactile', params=[
     xmlr.Attribute('channel', str),
-    xmlr.Element('array', TactileArrayElement, False)
+    xmlr.Element('array', TactileArrayElement),
+    xmlr.Element('taxel', xmlr.RawType(), False)
 ])
 
 
@@ -545,7 +547,7 @@ class TactileTaxelElement(xmlr.Object):
         self.geometry = geometry
 
 
-xmlr.reflect(TactileTaxelElement, tag='tactile_taxel_element', params=[
+xmlr.reflect(TactileTaxelElement, tag='array', params=[
     xmlr.Attribute('idx', float), 
     xmlr.Attribute('xyz', 'vector3', False, default=[0, 0, 0]),
     xmlr.Attribute('rpy', 'vector3', False, default=[0, 0, 0]),
@@ -557,13 +559,15 @@ class TactileTaxels(Tactile):
         Tactile.__init__(self, channel=channel)
         self.taxel = taxel
         self.taxels=[]
+        self.array = None
     # the test is very important in DuckTyping, if no fail, won't test the second type
     def check_valid(self):
         assert self.taxel is not None
 
-xmlr.reflect(TactileTaxels, tag='tactile_taxels', params=[
+xmlr.reflect(TactileTaxels, tag='tactile', params=[
     xmlr.Attribute('channel', str),
-    xmlr.AggregateElement('taxel', TactileTaxelElement, False)
+    xmlr.AggregateElement('taxel', TactileTaxelElement),
+    xmlr.Element('array', xmlr.RawType(), False)
 ])
 
 

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -637,25 +637,40 @@ xmlr.reflect(SensorTactile, tag='sensor_tactile', params=[
 
 
 
-class Camera(xmlr.Object):
-    def __init__(self, name=None, width=None, height=None,
-        pixelformat="R8G8B8", hfov=None, near=None, far=None):
+class CameraImage(xmlr.Object):
+    def __init__(self, width=None, height=None,
+        format="R8G8B8", hfov=None, near=None, far=None):
         self.width = int(width) if width is not None else None 
         self.height = int(height) if height is not None else None
         # format is optional: defaults to R8G8B8), but can be
         # (L8|R8G8B8|B8G8R8|BAYER_RGGB8|BAYER_BGGR8|BAYER_GBRG8|BAYER_GRBG8)
-        self.format = pixelformatformat
+        self.format = format
         self.hfov = hfov
         self.near = near
         self.far = far
 
-xmlr.reflect(Camera, tag='camera', params=[
+    def check_valid(self):
+        assert self.width is not None
+
+xmlr.reflect(CameraImage, tag='image', params=[
     xmlr.Attribute('width', float),
     xmlr.Attribute('height', float),
-    xmlr.Attribute('format', str),
+    xmlr.Attribute('format', str, False),
     xmlr.Attribute('hfov', float),
     xmlr.Attribute('near', float),
     xmlr.Attribute('far', float)
+])
+
+
+class Camera(xmlr.Object):
+    def __init__(self, image=None):
+        self.image = image
+
+    def check_valid(self):
+        assert self.image is not None
+
+xmlr.reflect(Camera, tag='camera', params=[
+    xmlr.Element('image', CameraImage, False)
 ])
 
 

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -496,8 +496,8 @@ class TactileArrayElement(xmlr.Object):
     COLUMNMAJOR="column-major"
     def __init__(self, rows=None, cols=None, order=None,
         size=None, spacing=None, offset=None):
-        self.rows = int(rows) if rows is not None else None
-        self.cols = int(cols) if cols is not None else None
+        self.rows = rows
+        self.cols = cols
         self.order = order
         self.size = size
         self.offset = offset
@@ -506,6 +506,9 @@ class TactileArrayElement(xmlr.Object):
     def check_valid(self):
         if self.spacing is None:
             self.spacing = self.size
+        # fix int here, it appears to not be possible in init because params are not set at init
+        self.rows = int(self.rows) if self.rows is not None else None
+        self.cols = int(self.cols) if self.cols is not None else None
         assert self.order in [self.ROWMAJOR, self.COLUMNMAJOR], ("order should be " + str(self.ROWMAJOR) + " or " + str(self.COLUMNMAJOR))
 
 

--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -1,14 +1,21 @@
 import string
 import yaml
 import collections
-from lxml import etree
+
+from xml.etree import ElementTree as ET
+from xml.dom import minidom
+
 
 def xml_string(rootXml, addHeader=True):
-    # Meh
-    xmlString = etree.tostring(rootXml, pretty_print=True, encoding='unicode')
-    if addHeader:
-        xmlString = '<?xml version="1.0"?>\n' + xmlString
-    return xmlString
+    # From: https://stackoverflow.com/a/1206856/170413
+    # TODO(eacousineau): This does not preserve attribute order. Fix it.
+    dom = minidom.parseString(ET.tostring(rootXml))
+    xml_string = ""
+    lines = dom.toprettyxml(indent="  ").split("\n")
+    if lines and lines[0].startswith("<?xml") and not addHeader:
+        del lines[0]
+    # N.B. Minidom injects some pure-whitespace lines. Remove them.
+    return "\n".join(filter(lambda line: line.strip(), lines))
 
 
 def dict_sub(obj, keys):
@@ -19,8 +26,8 @@ def node_add(doc, sub):
     if sub is None:
         return None
     if type(sub) == str:
-        return etree.SubElement(doc, sub)
-    elif isinstance(sub, etree._Element):
+        return ET.SubElement(doc, sub)
+    elif isinstance(sub, ET.Element):
         doc.append(sub)  # This screws up the rest of the tree for prettyprint
         return sub
     else:
@@ -32,11 +39,7 @@ def pfloat(x):
 
 
 def xml_children(node):
-    children = node.getchildren()
-
-    def predicate(node):
-        return not isinstance(node, etree._Comment)
-    return list(filter(predicate, children))
+    return node.getchildren()
 
 
 def isstring(obj):
@@ -57,8 +60,8 @@ def to_yaml(obj):
         return obj
     elif hasattr(obj, 'to_yaml'):
         out = obj.to_yaml()
-    elif isinstance(obj, etree._Element):
-        out = etree.tostring(obj, pretty_print=True)
+    elif isinstance(obj, type(ET.Element)):
+        out = xml_string(obj, addHeader=False)
     elif type(obj) == dict:
         out = {}
         for (var, value) in obj.items():

--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -39,7 +39,7 @@ def pfloat(x):
 
 
 def xml_children(node):
-    return node.getchildren()
+    return list(node)
 
 
 def isstring(obj):

--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -6,6 +6,7 @@ from xml.etree import ElementTree as ET
 from xml.dom import minidom
 
 
+
 def xml_string(rootXml, addHeader=True):
     # From: https://stackoverflow.com/a/1206856/170413
     # TODO(eacousineau): This does not preserve attribute order. Fix it.

--- a/src/urdf_parser_py/xml_reflection/core.py
+++ b/src/urdf_parser_py/xml_reflection/core.py
@@ -1,8 +1,12 @@
-from urdf_parser_py.xml_reflection.basics import *
 import sys
 import copy
 
-# @todo Get rid of "import *"
+from urdf_parser_py.xml_reflection.basics import node_add
+from urdf_parser_py.xml_reflection.basics import xml_children
+from urdf_parser_py.xml_reflection.basics import xml_string
+from urdf_parser_py.xml_reflection.basics import YamlReflection
+from xml.etree import ElementTree as ET
+
 # @todo Make this work with decorators
 
 # Is this reflection or serialization? I think it's serialization...
@@ -580,7 +584,7 @@ class Object(YamlReflection):
         """ Creates an overarching tag and adds its contents to the node """
         tag = self.XML_REFL.tag
         assert tag is not None, "Must define 'tag' in reflection to use this function"  # noqa
-        doc = etree.Element(tag)
+        doc = ET.Element(tag)
         self.write_xml(doc)
         return doc
 
@@ -607,8 +611,8 @@ class Object(YamlReflection):
 
     @classmethod
     def from_xml_string(cls, xml_string):
-        node = etree.fromstring(xml_string)
-        path = Path(cls.XML_REFL.tag, tree=etree.ElementTree(node))
+        node = ET.fromstring(xml_string)
+        path = Path(cls.XML_REFL.tag, tree=ET.ElementTree(node))
         return cls.from_xml(node, path)
 
     @classmethod
@@ -660,8 +664,8 @@ class Object(YamlReflection):
     """ Compatibility """
 
     def parse(self, xml_string):
-        node = etree.fromstring(xml_string)
-        path = Path(self.XML_REFL.tag, tree=etree.ElementTree(node))
+        node = ET.fromstring(xml_string)
+        path = Path(self.XML_REFL.tag, tree=ET.ElementTree(node))
         self.read_xml(node, path)
         return self
 

--- a/src/urdf_parser_py/xml_reflection/core.py
+++ b/src/urdf_parser_py/xml_reflection/core.py
@@ -26,10 +26,13 @@ def reflect(cls, *args, **kwargs):
 # 'pre_dump' and 'post_load'?
 # When dumping to yaml, include tag name?
 
+
 # How to incorporate line number and all that jazz?
 def on_error_stderr(message):
     """ What to do on an error. This can be changed to raise an exception. """
     sys.stderr.write(message + '\n')
+
+
 on_error = on_error_stderr
 
 
@@ -107,7 +110,7 @@ class Path(object):
         self.parent = parent
         self.tag = tag
         self.suffix = suffix
-        self.tree = tree # For validating general path (getting true XML path)
+        self.tree = tree  # For validating general path (getting true XML path)
 
     def __str__(self):
         if self.parent is not None:
@@ -117,6 +120,7 @@ class Path(object):
                 return "/{}{}".format(self.tag, self.suffix)
             else:
                 return self.suffix
+
 
 class ParseError(Exception):
     def __init__(self, e, path):
@@ -475,11 +479,11 @@ class Reflection(object):
             return attr_path
 
         def get_element_path(element):
-            element_path = Path(element.xml_var, parent = path)
+            element_path = Path(element.xml_var, parent=path)
             # Add an index (allow this to be overriden)
             if element.is_aggregate:
                 values = obj.get_aggregate_list(element.xml_var)
-                index = 1 + len(values) # 1-based indexing for W3C XPath
+                index = 1 + len(values)  # 1-based indexing for W3C XPath
                 element_path.suffix = "[{}]".format(index)
             return element_path
 
@@ -529,7 +533,7 @@ class Reflection(object):
             except ParseError:
                 raise
             except Exception as e:
-                raise ParseError(e, path) # get_attr_path(attribute.xml_var)
+                raise ParseError(e, path)  # get_attr_path(attribute.xml_var)
 
         for element in map(self.element_map.get, unset_scalars):
             try:
@@ -537,7 +541,7 @@ class Reflection(object):
             except ParseError:
                 raise
             except Exception as e:
-                raise ParseError(e, path) # get_element_path(element)
+                raise ParseError(e, path)  # get_element_path(element)
 
         if is_final:
             for xml_var in info.attributes:

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -37,7 +37,7 @@ class TestURDFParser(unittest.TestCase):
         orig_xml = minidom.parseString(xml)
         self.assertTrue(xml_matches(robot_xml, orig_xml))
 
-    def test_sensor_tactile(self):
+    def test_sensor_tactile_array(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0">
   <sensor name="my_tactile_sensor" group="my_group" update_rate="100">

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -37,6 +37,32 @@ class TestURDFParser(unittest.TestCase):
         orig_xml = minidom.parseString(xml)
         self.assertTrue(xml_matches(robot_xml, orig_xml))
 
+    def test_sensor_tactile(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.0">
+  <sensor name="my_tactile_sensor" group="my_group" update_rate="100">
+    <parent link="my_tactile_mount"/>
+    <origin xyz="1.0 2.0 3.0" rpy="0.4 0.5 0.6"/>
+    <tactile channel="my_channel">
+       <array rows="8" cols="16" order="row-major" 
+              size="0.07 0.09" spacing="0.1 0.11" offset="0.12 0.13"/>
+    </tactile>
+  </sensor>
+</robot>'''
+        self.parse_and_compare(xml)
+
+        robot = urdf.Robot(name='test', version='1.0')
+        arrayelement = urdf.TactileArrayElement(8, 16, "row-major",
+            [0.07, 0.09], [0.1,  0.11], [0.12, 0.13])
+        array = urdf.TactileArray(channel='my_channel', array=arrayelement)
+        sensor = urdf.SensorTactile(name='my_tactile_sensor', parent="my_tactile_mount", tactile=array)
+        sensor.origin = urdf.Pose([1.0, 2.0, 3.0], [0.4, 0.5, 0.6])
+        sensor.group = 'my_group'
+        sensor.update_rate = 100
+        sensor.parent_link = "my_tactile_mount"
+        robot.add_aggregate('sensor', sensor)
+        self.xml_and_compare(robot, xml)
+
     def test_new_transmission(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0">

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -283,6 +283,19 @@ class TestURDFParser(unittest.TestCase):
         robot.add_link(link)
         self.xml_and_compare(robot, xml)
 
+    def test_collision_with_name(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.0">
+  <link name="link">
+    <collision name="alice">
+      <geometry>
+        <cylinder length="1" radius="1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>'''
+        self.parse_and_compare(xml)
+
     def test_version_attribute_not_enough_dots(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1">

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -483,5 +483,21 @@ class LinkMultiVisualsAndCollisionsTest(unittest.TestCase):
         orig_xml = minidom.parseString(self.xml)
         self.assertTrue(xml_matches(robot_xml, orig_xml))
 
+class TestCreateNew(unittest.TestCase):
+    def test_new_urdf(self):
+        testcase = urdf.URDF('robot_name').to_xml()
+        self.assertTrue('name' in testcase.keys())
+        self.assertTrue('version' in testcase.keys())
+        self.assertEqual(testcase.get('name'), 'robot_name')
+        self.assertEqual(testcase.get('version'), '1.0')
+
+    def test_new_urdf_with_version(self):
+        testcase = urdf.URDF('robot_name', '1.0').to_xml()
+        self.assertTrue('name' in testcase.keys())
+        self.assertTrue('version' in testcase.keys())
+        self.assertEqual(testcase.get('name'), 'robot_name')
+        self.assertEqual(testcase.get('version'), '1.0')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -1,4 +1,3 @@
-
 import unittest
 import mock
 import os
@@ -13,6 +12,7 @@ from xml.dom import minidom  # noqa
 from xml_matching import xml_matches  # noqa
 from urdf_parser_py import urdf  # noqa
 import urdf_parser_py.xml_reflection as xmlr
+
 
 class ParseException(xmlr.core.ParseError):
     def __init__(self, e = "", path = ""):
@@ -38,7 +38,7 @@ class TestURDFParser(unittest.TestCase):
         self.assertTrue(xml_matches(robot_xml, orig_xml))
 
     def test_sensor_unknown(self):
-        # TODO currently  <unknown/> not added when unknown sensors  
+        # TODO currently  <unknown/> not added when unknown sensors
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0">
    <sensor name="unknown sensor" group="" update_rate="20.0">
@@ -51,7 +51,7 @@ class TestURDFParser(unittest.TestCase):
         self.parse_and_compare(xml)
         robot = self.parse(xml)
         sensor = robot.sensors[0]
-        self.assertEqual(sensor.name , 'unknown')
+        self.assertEqual(sensor.name, 'unknown')
 
     def test_sensor_ray(self):
         xml = '''<?xml version="1.0"?>
@@ -101,7 +101,6 @@ class TestURDFParser(unittest.TestCase):
         robot.add_aggregate('sensor', sensor)
         self.xml_and_compare(robot, xml)
 
-
     def test_sensor_tactile_taxel(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0">
@@ -125,7 +124,8 @@ class TestURDFParser(unittest.TestCase):
         self.parse_and_compare(xml)
 
         robot = urdf.Robot(name='test', version='1.0')
-        meshgeometry = urdf.Mesh(filename="package://sensor_description/model/my_tactiles/tax_lower.stl", scale=[0.00101, 0.00101, 0.00101])
+        meshgeometry = urdf.Mesh(filename="package://sensor_description/model/my_tactiles/tax_lower.stl",
+                                 scale=[0.00101, 0.00101, 0.00101])
         taxelelement = urdf.TactileTaxelElement(0, [0.02, 0.03, 0.04], [0.5, 0.6, 0.7], meshgeometry)
         taxel = urdf.TactileTaxels(channel='my_channel')
         taxel.add_aggregate('taxel', taxelelement)
@@ -657,6 +657,7 @@ class LinkMultiVisualsAndCollisionsTest(unittest.TestCase):
         robot_xml = minidom.parseString(robot_xml_string)
         orig_xml = minidom.parseString(self.xml)
         self.assertTrue(xml_matches(robot_xml, orig_xml))
+
 
 class TestCreateNew(unittest.TestCase):
     def test_new_urdf(self):


### PR DESCRIPTION
urdf_parser_py is missing parsers for our tactile definition and for other sensors available in our urdfdom
I had to extend urdf_parser_py  to permit use of our tactile description in an rqt_bag tactile_msgs display plugin that I prepared for one colleague. This new plugin will be added soon to our code base but requires this PR to be merged first.

No urgency, just needs to be done at some point before end of 2021 